### PR TITLE
Use previously declared passport scopes and merge with OIDC scopes

### DIFF
--- a/src/Laravel/PassportServiceProvider.php
+++ b/src/Laravel/PassportServiceProvider.php
@@ -35,7 +35,11 @@ class PassportServiceProvider extends Passport\PassportServiceProvider
             __DIR__ . '/config/openid.php' => $this->app->configPath('openid.php'),
         ], ['openid', 'openid-config']);
 
-        Passport\Passport::tokensCan(config('openid.passport.tokens_can'));
+        $openIdScopes = collect(config('openid.passport.tokens_can'));
+        $previousScopes = collect(Passport\Passport::scopes())->mapWithKeys(function (Passport\Scope $scope) {
+            return [$scope->id => $scope->description];
+        });
+        Passport\Passport::tokensCan($previousScopes->merge($openIdScopes)->toArray());
     }
 
     public function makeAuthorizationServer(): AuthorizationServer


### PR DESCRIPTION
Currently PassportServiceProvider overwrites the scopes Passport recognizes with only the OIDC scopes provided in the config file:

`Passport\Passport::tokensCan(config('openid.passport.tokens_can'));`

This PR takes into account scopes that may have already been defined to be used by Passport and merges them with the OIDC scopes. It uses the Collection helper merge where the OIDC scopes will take precedence in the case of duplicates.

```
$openIdScopes = collect(config('openid.passport.tokens_can'));
$previousScopes = collect(Passport\Passport::scopes())->mapWithKeys(function (Passport\Scope $scope) {
    return [$scope->id => $scope->description];
});
Passport\Passport::tokensCan($previousScopes->merge($openIdScopes)->toArray());
```

If no scopes were previously defined, no behavior changes.