### PR TITLE
Making the issuer configurable.

### DIFF
--- a/src/IdTokenResponse.php
+++ b/src/IdTokenResponse.php
@@ -21,15 +21,18 @@ class IdTokenResponse extends BearerTokenResponse
     protected ClaimExtractor $claimExtractor;
 
     private Configuration $config;
+    private ?string $issuer;
 
     public function __construct(
         IdentityRepositoryInterface $identityRepository,
         ClaimExtractor $claimExtractor,
-        Configuration $config
+        Configuration $config,
+        string $issuer = null,
     ) {
         $this->identityRepository = $identityRepository;
         $this->claimExtractor = $claimExtractor;
         $this->config = $config;
+        $this->issuer = $issuer;
     }
 
     protected function getBuilder(
@@ -41,7 +44,7 @@ class IdTokenResponse extends BearerTokenResponse
         return $this->config
             ->builder()
             ->permittedFor($accessToken->getClient()->getIdentifier())
-            ->issuedBy('https://' . $_SERVER['HTTP_HOST'])
+            ->issuedBy($this->issuer ?? 'https://' . $_SERVER['HTTP_HOST'])
             ->issuedAt($dateTimeImmutableObject)
             ->expiresAt($dateTimeImmutableObject->add(new DateInterval('PT1H')))
             ->relatedTo($userEntity->getIdentifier());

--- a/src/Laravel/PassportServiceProvider.php
+++ b/src/Laravel/PassportServiceProvider.php
@@ -55,6 +55,7 @@ class PassportServiceProvider extends Passport\PassportServiceProvider
                 app(config('openid.signer')),
                 InMemory::file($cryptKey->getKeyPath()),
             ),
+            app('request')->getSchemeAndHttpHost(),
         );
 
         return new AuthorizationServer(

--- a/tests/Factories/IdTokenResponseFactory.php
+++ b/tests/Factories/IdTokenResponseFactory.php
@@ -16,26 +16,30 @@ class IdTokenResponseFactory
         IdentityRepositoryInterface $identityRepository,
         ClaimExtractor $claimExtractor,
         ?Configuration $config = null,
+        ?string $issuer = null,
     ): BearerTokenResponse {
         return new IdTokenResponse(
             $identityRepository,
             $claimExtractor,
             $config ?? ConfigutationFactory::default(),
+            $issuer,
         );
     }
 
     public static function default(
         IdentityRepositoryInterface $identityRepository,
         ClaimExtractor $claimExtractor,
+        ?string $issuer = null,
     ): BearerTokenResponse {
-        return (new static())->build($identityRepository, $claimExtractor);
+        return (new static())->build($identityRepository, $claimExtractor, null, $issuer);
     }
 
     public static function withConfig(
         IdentityRepositoryInterface $identityRepository,
         ClaimExtractor $claimExtractor,
-        Configuration $config
+        Configuration $config,
+        ?string $issuer = null,
     ): BearerTokenResponse {
-        return (new static())->build($identityRepository, $claimExtractor, $config);
+        return (new static())->build($identityRepository, $claimExtractor, $config, $issuer);
     }
 }


### PR DESCRIPTION
So far, the issuer was generated using `'https://' . $_SERVER['HTTP_HOST']`.

While this value is fine most of the time, it can cause trouble in:

- development environments (where the protocol is `http://`)
- long-lived PHP environments (like Swoole, ReactPHP...) where `$_SERVER['HTTP_HOST']` might not exist

I'm trying here to make the issuer configurable by adding an additional parameter to the `IdTokenResponse` constructor.
The new `$issuer` parameter is nullable and will fallback to the old behaviour in order not to break existing code.

This fixes #13