### PR TITLE
Adding support for a nonce

### DIFF
--- a/.github/workflows/php74.yml
+++ b/.github/workflows/php74.yml
@@ -1,6 +1,10 @@
 name: PHP 7.4
 
-on: push
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   php74:

--- a/.github/workflows/php80.yml
+++ b/.github/workflows/php80.yml
@@ -1,6 +1,10 @@
 name: PHP 8.0
 
-on: push
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   php80:

--- a/.github/workflows/php81.yml
+++ b/.github/workflows/php81.yml
@@ -1,6 +1,10 @@
 name: PHP 8.1
 
-on: push
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   php80:

--- a/.github/workflows/php82.yml
+++ b/.github/workflows/php82.yml
@@ -1,6 +1,10 @@
 name: PHP 8.2
 
-on: push
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   php80:

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ To enable OpenID Connect, follow these simple steps
 ```php
 $privateKeyPath = 'tmp/private.key';
 
+$currentRequestService = new CurrentRequestService();
+$currentRequestService->setRequest(ServerRequestFactory::fromGlobals());
+
 // create the response_type
 $responseType = new IdTokenResponse(
     new IdentityRepository(),
@@ -44,6 +47,8 @@ $responseType = new IdTokenResponse(
         new Sha256(),
         InMemory::file($privateKeyPath),
     ),
+    $currentRequestService,
+    $encryptionKey,
 );
 
 $server = new \League\OAuth2\Server\AuthorizationServer(
@@ -61,6 +66,17 @@ Now when calling the `/authorize` endpoint, provide the `openid` scope to get an
 Provide more scopes (e.g. `openid profile email`) to receive additional claims in the `id_token`.
 
 For a complete implementation, visit [the OAuth2 Server example](https://github.com/ronvanderheijden/openid-connect/tree/main/example).
+
+## Nonce support
+
+To prevent replay attacks, some clients can provide a "nonce" in the authorization request. If a client does so, the
+server MUST include back a `nonce` claim in the `id_token`.
+
+To enable this feature, when registering an AuthCodeGrant, you need to use the `\OpenIDConnect\Grant\AuthCodeGrant` 
+instead of `\League\OAuth2\Server\Grant\AuthCodeGrant`.
+
+> ![NOTE]
+> If you are using Laravel, the `AuthCodeGrant` is already registered for you by the service provider.
 
 ## Laravel Passport
 
@@ -141,7 +157,6 @@ discovery document by naming the route `openid.userinfo`.
 ```php
 Route::get('/oauth/userinfo', 'YourController@userinfo')->middleware('xxx')->name('openid.userinfo');
 ```
-
 
 ## Support
 Found a bug? Got a feature request?  [Create an issue](https://github.com/ronvanderheijden/openid-connect/issues).

--- a/src/Grant/AuthCodeGrant.php
+++ b/src/Grant/AuthCodeGrant.php
@@ -1,12 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace OpenIDConnect\Grant;
 
 use DateInterval;
 use League\OAuth2\Server\Repositories\AuthCodeRepositoryInterface;
 use League\OAuth2\Server\Repositories\RefreshTokenRepositoryInterface;
 use League\OAuth2\Server\RequestTypes\AuthorizationRequest;
-use League\OAuth2\Server\ResponseTypes\RedirectResponse;
 use OpenIDConnect\Interfaces\CurrentRequestServiceInterface;
 use Psr\Http\Message\ResponseInterface;
 
@@ -25,10 +26,15 @@ class AuthCodeGrant extends \League\OAuth2\Server\Grant\AuthCodeGrant
      * @param RefreshTokenRepositoryInterface $refreshTokenRepository
      * @param DateInterval $authCodeTTL
      * @param ResponseInterface $psr7Response An empty PSR-7 Response object
-     * @param CurrentRequestServiceInterface $currentRequestService A service that returns the current request. Used to get the nonce parameter.
+     * @param CurrentRequestServiceInterface $currentRequestService A service that returns the current request.
+     *                                                              Used to get the nonce parameter.
      * @throws \Exception
      */
-    public function __construct(AuthCodeRepositoryInterface $authCodeRepository, RefreshTokenRepositoryInterface $refreshTokenRepository, DateInterval $authCodeTTL, ResponseInterface $psr7Response, CurrentRequestServiceInterface $currentRequestService)
+    public function __construct(AuthCodeRepositoryInterface $authCodeRepository,
+                                RefreshTokenRepositoryInterface $refreshTokenRepository,
+                                DateInterval $authCodeTTL,
+                                ResponseInterface $psr7Response,
+                                CurrentRequestServiceInterface $currentRequestService)
     {
         parent::__construct($authCodeRepository, $refreshTokenRepository, $authCodeTTL);
         $this->psr7Response = $psr7Response;
@@ -48,7 +54,8 @@ class AuthCodeGrant extends \League\OAuth2\Server\Grant\AuthCodeGrant
         $queryParams = $this->currentRequestService->getRequest()->getQueryParams();
 
         if (isset($queryParams['nonce'])) {
-            // The only way to get the redirect URI is to generate the PSR7 response (The RedirectResponse class does not have a getter for the redirect URI)
+            // The only way to get the redirect URI is to generate the PSR7 response
+            // (The RedirectResponse class does not have a getter for the redirect URI)
             $httpResponse = $response->generateHttpResponse($this->psr7Response);
             $redirectUri = $httpResponse->getHeader('Location')[0];
             $parsed = parse_url($redirectUri);
@@ -77,14 +84,14 @@ class AuthCodeGrant extends \League\OAuth2\Server\Grant\AuthCodeGrant
      */
     private function unparse_url($parsed_url)
     {
-        $scheme   = isset($parsed_url['scheme']) ? $parsed_url['scheme'] . '://' : '';
-        $host     = isset($parsed_url['host']) ? $parsed_url['host'] : '';
-        $port     = isset($parsed_url['port']) ? ':' . $parsed_url['port'] : '';
-        $user     = isset($parsed_url['user']) ? $parsed_url['user'] : '';
-        $pass     = isset($parsed_url['pass']) ? ':' . $parsed_url['pass'] : '';
-        $pass     = ($user || $pass) ? "$pass@" : '';
-        $path     = isset($parsed_url['path']) ? $parsed_url['path'] : '';
-        $query    = isset($parsed_url['query']) ? '?' . $parsed_url['query'] : '';
+        $scheme = isset($parsed_url['scheme']) ? $parsed_url['scheme'] . '://' : '';
+        $host = isset($parsed_url['host']) ? $parsed_url['host'] : '';
+        $port = isset($parsed_url['port']) ? ':' . $parsed_url['port'] : '';
+        $user = isset($parsed_url['user']) ? $parsed_url['user'] : '';
+        $pass = isset($parsed_url['pass']) ? ':' . $parsed_url['pass'] : '';
+        $pass = ($user || $pass) ? "$pass@" : '';
+        $path = isset($parsed_url['path']) ? $parsed_url['path'] : '';
+        $query = isset($parsed_url['query']) ? '?' . $parsed_url['query'] : '';
         $fragment = isset($parsed_url['fragment']) ? '#' . $parsed_url['fragment'] : '';
         return "$scheme$user$pass$host$port$path$query$fragment";
     }

--- a/src/Grant/AuthCodeGrant.php
+++ b/src/Grant/AuthCodeGrant.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace OpenIDConnect\Grant;
+
+use DateInterval;
+use League\OAuth2\Server\Repositories\AuthCodeRepositoryInterface;
+use League\OAuth2\Server\Repositories\RefreshTokenRepositoryInterface;
+use League\OAuth2\Server\RequestTypes\AuthorizationRequest;
+use League\OAuth2\Server\ResponseTypes\RedirectResponse;
+use OpenIDConnect\Interfaces\CurrentRequestServiceInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * This class extends the default AuthCodeGrant class to add support for the nonce parameter.
+ *
+ * The nonce parameter is
+ */
+class AuthCodeGrant extends \League\OAuth2\Server\Grant\AuthCodeGrant
+{
+    private ResponseInterface $psr7Response;
+    private CurrentRequestServiceInterface $currentRequestService;
+
+    /**
+     * @param AuthCodeRepositoryInterface $authCodeRepository
+     * @param RefreshTokenRepositoryInterface $refreshTokenRepository
+     * @param DateInterval $authCodeTTL
+     * @param ResponseInterface $psr7Response An empty PSR-7 Response object
+     * @param CurrentRequestServiceInterface $currentRequestService A service that returns the current request. Used to get the nonce parameter.
+     * @throws \Exception
+     */
+    public function __construct(AuthCodeRepositoryInterface $authCodeRepository, RefreshTokenRepositoryInterface $refreshTokenRepository, DateInterval $authCodeTTL, ResponseInterface $psr7Response, CurrentRequestServiceInterface $currentRequestService)
+    {
+        parent::__construct($authCodeRepository, $refreshTokenRepository, $authCodeTTL);
+        $this->psr7Response = $psr7Response;
+        $this->currentRequestService = $currentRequestService;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function completeAuthorizationRequest(AuthorizationRequest $authorizationRequest)
+    {
+        // See https://github.com/steverhoades/oauth2-openid-connect-server/issues/47#issuecomment-1228370632
+
+        /** @var RedirectResponse $response */
+        $response = parent::completeAuthorizationRequest($authorizationRequest);
+
+        $queryParams = $this->currentRequestService->getRequest()->getQueryParams();
+
+        if (isset($queryParams['nonce'])) {
+            // The only way to get the redirect URI is to generate the PSR7 response (The RedirectResponse class does not have a getter for the redirect URI)
+            $httpResponse = $response->generateHttpResponse($this->psr7Response);
+            $redirectUri = $httpResponse->getHeader('Location')[0];
+            $parsed = parse_url($redirectUri);
+
+            parse_str($parsed['query'], $query);
+
+            $authCodePayload = json_decode($this->decrypt($query['code']), true, 512, JSON_THROW_ON_ERROR);
+
+            $authCodePayload['nonce'] = $queryParams['nonce'];
+
+            $query['code'] = $this->encrypt(json_encode($authCodePayload, JSON_THROW_ON_ERROR));
+
+            $parsed['query'] = http_build_query($query);
+
+            $response->setRedirectUri($this->unparse_url($parsed));
+        }
+
+        return $response;
+    }
+
+    /**
+     * Inverse of parse_url
+     *
+     * @param mixed $parsed_url
+     * @return string
+     */
+    private function unparse_url($parsed_url)
+    {
+        $scheme   = isset($parsed_url['scheme']) ? $parsed_url['scheme'] . '://' : '';
+        $host     = isset($parsed_url['host']) ? $parsed_url['host'] : '';
+        $port     = isset($parsed_url['port']) ? ':' . $parsed_url['port'] : '';
+        $user     = isset($parsed_url['user']) ? $parsed_url['user'] : '';
+        $pass     = isset($parsed_url['pass']) ? ':' . $parsed_url['pass'] : '';
+        $pass     = ($user || $pass) ? "$pass@" : '';
+        $path     = isset($parsed_url['path']) ? $parsed_url['path'] : '';
+        $query    = isset($parsed_url['query']) ? '?' . $parsed_url['query'] : '';
+        $fragment = isset($parsed_url['fragment']) ? '#' . $parsed_url['fragment'] : '';
+        return "$scheme$user$pass$host$port$path$query$fragment";
+    }
+}

--- a/src/IdTokenResponse.php
+++ b/src/IdTokenResponse.php
@@ -6,7 +6,6 @@ namespace OpenIDConnect;
 
 use DateInterval;
 use DateTimeImmutable;
-use Defuse\Crypto\Key;
 use Lcobucci\JWT\Builder;
 use Lcobucci\JWT\Configuration;
 use League\OAuth2\Server\CryptTrait;

--- a/src/IdTokenResponse.php
+++ b/src/IdTokenResponse.php
@@ -6,33 +6,43 @@ namespace OpenIDConnect;
 
 use DateInterval;
 use DateTimeImmutable;
+use Defuse\Crypto\Key;
 use Lcobucci\JWT\Builder;
 use Lcobucci\JWT\Configuration;
+use League\OAuth2\Server\CryptTrait;
 use League\OAuth2\Server\Entities\AccessTokenEntityInterface;
 use League\OAuth2\Server\Entities\ScopeEntityInterface;
 use League\OAuth2\Server\ResponseTypes\BearerTokenResponse;
+use OpenIDConnect\Interfaces\CurrentRequestServiceInterface;
 use OpenIDConnect\Interfaces\IdentityEntityInterface;
 use OpenIDConnect\Interfaces\IdentityRepositoryInterface;
 
 class IdTokenResponse extends BearerTokenResponse
 {
+    use CryptTrait;
+
     protected IdentityRepositoryInterface $identityRepository;
 
     protected ClaimExtractor $claimExtractor;
 
     private Configuration $config;
-    private ?string $issuer;
+    private ?CurrentRequestServiceInterface $currentRequestService;
 
+    /**
+     * @param string|Key|null $encryptionKey
+     */
     public function __construct(
         IdentityRepositoryInterface $identityRepository,
         ClaimExtractor $claimExtractor,
         Configuration $config,
-        string $issuer = null,
+        CurrentRequestServiceInterface $currentRequestService = null,
+        $encryptionKey = null,
     ) {
         $this->identityRepository = $identityRepository;
         $this->claimExtractor = $claimExtractor;
         $this->config = $config;
-        $this->issuer = $issuer;
+        $this->currentRequestService = $currentRequestService;
+        $this->encryptionKey = $encryptionKey;
     }
 
     protected function getBuilder(
@@ -41,10 +51,17 @@ class IdTokenResponse extends BearerTokenResponse
     ): Builder {
         $dateTimeImmutableObject = new DateTimeImmutable();
 
+        if ($this->currentRequestService) {
+            $uri = $this->currentRequestService->getRequest()->getUri();
+            $issuer = $uri->getScheme() . '://' . $uri->getHost() . ($uri->getPort() ? ':' . $uri->getPort() : '');
+        } else {
+            $issuer = 'https://' . $_SERVER['HTTP_HOST'];
+        }
+
         return $this->config
             ->builder()
             ->permittedFor($accessToken->getClient()->getIdentifier())
-            ->issuedBy($this->issuer ?? 'https://' . $_SERVER['HTTP_HOST'])
+            ->issuedBy($issuer)
             ->issuedAt($dateTimeImmutableObject)
             ->expiresAt($dateTimeImmutableObject->add(new DateInterval('PT1H')))
             ->relatedTo($userEntity->getIdentifier());
@@ -69,6 +86,17 @@ class IdTokenResponse extends BearerTokenResponse
 
         foreach ($claims as $claimName => $claimValue) {
             $builder = $builder->withClaim($claimName, $claimValue);
+        }
+
+        if ($this->currentRequestService) {
+            // If the request contains a code, we look into the code to find the nonce.
+            $body = $this->currentRequestService->getRequest()->getParsedBody();
+            if (isset($body['code'])) {
+                $authCodePayload = json_decode($this->decrypt($body['code']), true, 512, JSON_THROW_ON_ERROR);
+                if (isset($authCodePayload['nonce'])) {
+                    $builder = $builder->withClaim('nonce', $authCodePayload['nonce']);
+                }
+            }
         }
 
         $token = $builder->getToken(

--- a/src/Interfaces/CurrentRequestServiceInterface.php
+++ b/src/Interfaces/CurrentRequestServiceInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace OpenIDConnect\Interfaces;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * A service in charge of returning the current request.
+ *
+ * This should be implemented by the application using this package (a default Laravel implementation is provided)
+ *
+ * We need this because due to the architecture of the League package, the request is not available in the
+ * grant classes. But we need access to the "nonce" parameter in the request to be able to include it in the
+ * ID token.
+ */
+interface CurrentRequestServiceInterface
+{
+    public function getRequest(): ServerRequestInterface;
+}

--- a/src/Interfaces/CurrentRequestServiceInterface.php
+++ b/src/Interfaces/CurrentRequestServiceInterface.php
@@ -1,4 +1,6 @@
-<?php
+<?php 
+
+declare(strict_types=1);
 
 namespace OpenIDConnect\Interfaces;
 

--- a/src/Laravel/LaravelCurrentRequestService.php
+++ b/src/Laravel/LaravelCurrentRequestService.php
@@ -1,4 +1,6 @@
-<?php
+<?php 
+
+declare(strict_types=1);
 
 namespace OpenIDConnect\Laravel;
 
@@ -9,7 +11,6 @@ use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
 
 class LaravelCurrentRequestService implements CurrentRequestServiceInterface
 {
-
     public function getRequest(): ServerRequestInterface
     {
         return (new PsrHttpFactory(

--- a/src/Laravel/LaravelCurrentRequestService.php
+++ b/src/Laravel/LaravelCurrentRequestService.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace OpenIDConnect\Laravel;
+
+use Nyholm\Psr7\Factory\Psr17Factory;
+use OpenIDConnect\Interfaces\CurrentRequestServiceInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
+
+class LaravelCurrentRequestService implements CurrentRequestServiceInterface
+{
+
+    public function getRequest(): ServerRequestInterface
+    {
+        return (new PsrHttpFactory(
+            new Psr17Factory,
+            new Psr17Factory,
+            new Psr17Factory,
+            new Psr17Factory
+        ))->createRequest(request());
+    }
+}

--- a/src/Laravel/PassportServiceProvider.php
+++ b/src/Laravel/PassportServiceProvider.php
@@ -11,7 +11,6 @@ use Laravel\Passport\Bridge\ClientRepository;
 use Lcobucci\JWT\Configuration;
 use Lcobucci\JWT\Signer\Key\InMemory;
 use League\OAuth2\Server\AuthorizationServer;
-use League\OAuth2\Server\CryptTrait;
 use Nyholm\Psr7\Response;
 use OpenIDConnect\ClaimExtractor;
 use OpenIDConnect\Claims\ClaimSet;

--- a/src/Services/CurrentRequestService.php
+++ b/src/Services/CurrentRequestService.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace OpenIDConnect\Services;
+
+use OpenIDConnect\Interfaces\CurrentRequestServiceInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class CurrentRequestService implements CurrentRequestServiceInterface
+{
+    private ?ServerRequestInterface $request;
+
+    public function getRequest(): ServerRequestInterface
+    {
+        if ($this->request === null) {
+            throw new \RuntimeException('Request not set in CurrentRequestService');
+        }
+        return $this->request;
+    }
+
+    public function setRequest(ServerRequestInterface $request): void
+    {
+        $this->request = $request;
+    }
+}

--- a/src/Services/CurrentRequestService.php
+++ b/src/Services/CurrentRequestService.php
@@ -1,4 +1,6 @@
-<?php
+<?php 
+
+declare(strict_types=1);
 
 namespace OpenIDConnect\Services;
 


### PR DESCRIPTION
According to the OpenID connect spec:

> nonce
> String value used to associate a Client session with an ID Token, and to mitigate replay attacks. The value is passed through unmodified from the Authentication Request to the ID Token. If present in the ID Token, Clients MUST verify that the nonce Claim Value is equal to the value of the nonce parameter sent in the Authentication Request. If present in the Authentication Request, Authorization Servers MUST include a nonce Claim in the ID Token with the Claim Value being the nonce value sent in the Authentication Request. Authorization Servers SHOULD perform no other processing on nonce values used. The nonce value is a case-sensitive string.

Right now, if a client passes a "nounce", we don't give it back and
the client fails. This is happening to me right now with the client
from Matrix Synapse.

Here, I'm creating a new service (`CurrentRequestService`).
With this new service, I can get the current PSR-7 request.

I extend the AuthCodeGrant and inject this service into the extended class.
With this, I can:

- read the "nonce" from the request
- encode the "nonce" in the "code"

Then, in the `IdTokenResponse`, I read the "code" (if it is present),
extract the "nounce" and inject it in the ID token as a new claim.

The whole process is inspired by this comment: https://github.com/steverhoades/oauth2-openid-connect-server/issues/47#issuecomment-1228370632

With those changes, nounce is correctly handled and I've successfully
tested a connection with the OpenID client from Matrix Synapse.

This PR is built on top of #16 