### PR TITLE
Setting to disable tokens_can

### DIFF
--- a/src/Laravel/PassportServiceProvider.php
+++ b/src/Laravel/PassportServiceProvider.php
@@ -35,7 +35,10 @@ class PassportServiceProvider extends Passport\PassportServiceProvider
             __DIR__ . '/config/openid.php' => $this->app->configPath('openid.php'),
         ], ['openid', 'openid-config']);
 
-        Passport\Passport::tokensCan(config('openid.passport.tokens_can'));
+        $tokens_can = config('openid.passport.tokens_can', null);
+        if ($tokens_can) {
+            Passport\Passport::tokensCan($tokens_can);
+        }
     }
 
     public function makeAuthorizationServer(): AuthorizationServer


### PR DESCRIPTION
For projects that need to register scopes in a ServiceProvider, allow for disabling this packages scope registration.

Resolving #19 