### PR TITLE
Fixing scopes_supported key in /.well-known/openid-configuration

### DIFF
--- a/src/Laravel/DiscoveryController.php
+++ b/src/Laravel/DiscoveryController.php
@@ -32,7 +32,7 @@ class DiscoveryController
             'id_token_signing_alg_values_supported' => [
                 'RS256',
             ],
-            'scopes_supported' => config('openid.passport.tokens_can'),
+            'scopes_supported' => array_keys(config('openid.passport.tokens_can')),
             'token_endpoint_auth_methods_supported' => [
                 'client_secret_basic',
                 'client_secret_post',


### PR DESCRIPTION
The scopes_supported key returned was an object, but according to the spec, it must be an array.
See https://openid.net/specs/openid-connect-discovery-1_0-37.html

Closes #25

Thanks @timcortesi