### PR TITLE
Fix conditional route registration

### DIFF
--- a/src/Laravel/routes/web.php
+++ b/src/Laravel/routes/web.php
@@ -6,12 +6,12 @@ use Illuminate\Support\Facades\Route;
 use OpenIDConnect\Laravel\DiscoveryController;
 use OpenIDConnect\Laravel\JwksController;
 
-if (config('openid.routes.discovery', true)) {
+if (config('openid.routes.jwks', true)) {
     Route::get('/oauth/jwks', JwksController::class)
         ->name('openid.jwks');
 }
 
-if (config('openid.routes.jwks', true)) {
+if (config('openid.routes.discovery', true)) {
     Route::get('/.well-known/openid-configuration', DiscoveryController::class)
         ->name('openid.discovery');
 }


### PR DESCRIPTION
Use the correct config values to determine if the `openid.jwks` and `openid.discovery` routes should be registered.