### PR TITLE
Fix issue where `str_replace` is called with `null`

### DIFF
--- a/src/Laravel/JwksController.php
+++ b/src/Laravel/JwksController.php
@@ -28,7 +28,7 @@ class JwksController
     }
 
     private function getPublicKey(): string {
-        $publicKey = str_replace('\\n', "\n", config('passport.public_key', ''));
+        $publicKey = str_replace('\\n', "\n", config('passport.public_key') ?? '');
 
         if (!$publicKey) {
             $publicKey = 'file://'.Passport::keyPath('oauth-public.key');


### PR DESCRIPTION
Ran into an error where `null` was returned from the `config('passport.public_key', '')` call due to no fallback being set in the `env()` call in my passport config.